### PR TITLE
Add CodeMirror syntax highlighting to code editors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
-  "name": "try-metaprogramming-ruby",
+  "name": "metaprogramming-challenges-in-ruby",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.1",
-        "@ruby/wasm-wasi": "^2.7.1"
+        "@codemirror/language": "^6.10.6",
+        "@codemirror/legacy-modes": "^6.4.1",
+        "@ruby/wasm-wasi": "^2.7.1",
+        "codemirror": "^6.0.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.48.0",
@@ -19,6 +22,96 @@
       "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.4.1.tgz",
       "integrity": "sha512-54kpBQX69TZ8I1zyDC8sziv/zPT1zoIadv3CmdIZNZ5WDF1houMjAzRZ3dwWvhXObiEBjOxXyS8Ja7vA0EfGEQ==",
       "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.18.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
+      "integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
+      "integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.4.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.2.tgz",
+      "integrity": "sha512-p44TsNArL4IVXDTbapUmEkAlvWs2CFQbcfc0ymDsis1kH2wh0gcY96AS29c/vp2d0y2Tquk1EDSaawpzilUiAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.1.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.1.tgz",
+      "integrity": "sha512-DJYQQ00N1/KdESpZV7jg9hafof/iBNp9h7TYo1SLMk86TWl9uDsVdho2dzd81K+v4retmK6mdC7WpuOQDytQqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
+      "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+      "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+      "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.38.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.1.tgz",
+      "integrity": "sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.3",
@@ -463,6 +556,36 @@
         "node": ">=12"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
+      "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
     "node_modules/@playwright/test": {
       "version": "1.54.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.1.tgz",
@@ -538,6 +661,21 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -556,6 +694,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -959,11 +1103,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "type": "module",
   "dependencies": {
     "@bjorn3/browser_wasi_shim": "^0.4.1",
-    "@ruby/wasm-wasi": "^2.7.1"
+    "@ruby/wasm-wasi": "^2.7.1",
+    "codemirror": "^6.0.1",
+    "@codemirror/language": "^6.10.6",
+    "@codemirror/legacy-modes": "^6.4.1"
   },
   "devDependencies": {
     "esbuild": "^0.25.3",

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@ import { RubyVM } from "@ruby/wasm-wasi";
 import { File, WASI, OpenFile, ConsoleStdout } from "@bjorn3/browser_wasi_shim";
 import { problems } from "./problems.js";
 import { LanguageManager } from "./i18n.js";
-import { RubyEditor } from "./ruby-editor.js";
+import { RubyEditor, ReadOnlyRubyEditor } from "./ruby-editor.js";
 
 class RubyRunner {
   constructor() {
@@ -201,6 +201,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const answerContainer = document.getElementById('answer-container');
   const answerExplanationText = document.getElementById('answer-explanation-text');
   const answerCodeText = document.getElementById('answer-code-text');
+  let answerCodeEditor = null; // Answer Example用のCodeMirrorインスタンス
   const testResult = document.getElementById('test-result');
   const loading = document.getElementById('loading');
   const languageJaBtn = document.getElementById('language-ja-btn');
@@ -353,9 +354,14 @@ document.addEventListener('DOMContentLoaded', () => {
       answerExplanationText.textContent = languageManager.t('noExplanation');
     }
 
-    // 回答コードを表示
+    // 回答コードを表示（CodeMirrorで）
     if (problem.answerCode) {
-      answerCodeText.textContent = problem.answerCode;
+      // 既存のエディタがあれば破棄
+      if (answerCodeEditor) {
+        answerCodeEditor.destroy();
+      }
+      // 新しい読み取り専用エディタを作成
+      answerCodeEditor = new ReadOnlyRubyEditor(answerCodeText, problem.answerCode);
     } else {
       answerCodeText.textContent = languageManager.t('noAnswer');
     }
@@ -366,6 +372,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // 回答を非表示
   function hideAnswer() {
+    // CodeMirrorエディタがあれば破棄
+    if (answerCodeEditor) {
+      answerCodeEditor.destroy();
+      answerCodeEditor = null;
+    }
     answerContainer.classList.add('hidden');
     showAnswerButton.textContent = languageManager.t('showAnswer');
   }

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import { RubyVM } from "@ruby/wasm-wasi";
 import { File, WASI, OpenFile, ConsoleStdout } from "@bjorn3/browser_wasi_shim";
 import { problems } from "./problems.js";
 import { LanguageManager } from "./i18n.js";
+import { RubyEditor } from "./ruby-editor.js";
 
 class RubyRunner {
   constructor() {
@@ -193,6 +194,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const problemSelect = document.getElementById('problem-select');
   const detailedDescriptionText = document.getElementById('detailed-description-text');
   const codeEditor = document.getElementById('code-editor');
+  const rubyEditor = new RubyEditor(codeEditor);
   const runButton = document.getElementById('run-button');
   const resetButton = document.getElementById('reset-button');
   const showAnswerButton = document.getElementById('show-answer-button');
@@ -301,7 +303,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const detailedDescriptionField = languageManager.getProblemField('detailedDescription');
       
       detailedDescriptionText.textContent = problem[detailedDescriptionField] || problem.detailedDescription || '';
-      codeEditor.value = problem.problemCode;
+      rubyEditor.setValue(problem.problemCode);
       rubyRunner.setTestCode(problem.testCode);
       
       // テスト結果をクリア
@@ -315,7 +317,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // 問題のリセット
   function resetProblem() {
     if (problemManager.currentProblem) {
-      codeEditor.value = problemManager.currentProblem.problemCode;
+      rubyEditor.setValue(problemManager.currentProblem.problemCode);
       testResult.textContent = '';
       testResult.className = '';
       hideAnswer();
@@ -412,7 +414,7 @@ document.addEventListener('DOMContentLoaded', () => {
       await rubyRunner.resetVM();
       rubyRunner.setTestCode(problemManager.currentProblem.testCode);
       
-      const userCode = codeEditor.value;
+      const userCode = rubyEditor.getValue();
       // テストの実行（問題IDを渡して実行順序を決定）
       const result = await rubyRunner.runTest(userCode, problemManager.currentProblem.id);
       console.log(result);

--- a/src/ruby-editor.js
+++ b/src/ruby-editor.js
@@ -67,3 +67,56 @@ export class RubyEditor {
     }
   }
 }
+
+export class ReadOnlyRubyEditor {
+  constructor(container, initialValue = '') {
+    this.container = container;
+    this.view = null;
+    this.init(initialValue);
+  }
+
+  init(initialValue) {
+    // コンテナをクリア
+    this.container.innerHTML = '';
+    
+    // エディタビューを作成（読み取り専用）
+    this.view = new EditorView({
+      doc: initialValue,
+      extensions: [
+        basicSetup,
+        StreamLanguage.define(ruby),
+        EditorView.editable.of(false), // 読み取り専用
+        EditorView.theme({
+          "&": {
+            backgroundColor: "#f5f5f5"
+          },
+          ".cm-content": {
+            cursor: "default" // カーソルを通常の矢印にする
+          },
+          ".cm-cursor": {
+            display: "none" // カーソルを非表示
+          }
+        })
+      ],
+      parent: this.container
+    });
+  }
+
+  setValue(value) {
+    if (this.view) {
+      this.view.dispatch({
+        changes: {
+          from: 0,
+          to: this.view.state.doc.length,
+          insert: value
+        }
+      });
+    }
+  }
+
+  destroy() {
+    if (this.view) {
+      this.view.destroy();
+    }
+  }
+}

--- a/src/ruby-editor.js
+++ b/src/ruby-editor.js
@@ -1,0 +1,69 @@
+import { EditorView, basicSetup } from "codemirror";
+import { StreamLanguage } from "@codemirror/language";
+import { ruby } from "@codemirror/legacy-modes/mode/ruby";
+
+export class RubyEditor {
+  constructor(textarea) {
+    this.textarea = textarea;
+    this.view = null;
+    this.init();
+  }
+
+  init() {
+    // textareaを非表示にして、CodeMirrorエディタで置き換える
+    this.textarea.style.display = 'none';
+    
+    // CodeMirrorコンテナを作成
+    const container = document.createElement('div');
+    container.className = 'codemirror-container';
+    this.textarea.parentNode.insertBefore(container, this.textarea);
+
+    // エディタビューを作成
+    this.view = new EditorView({
+      doc: this.textarea.value,
+      extensions: [
+        basicSetup,
+        StreamLanguage.define(ruby),
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            // textareaの値を更新
+            this.textarea.value = update.state.doc.toString();
+            // inputイベントを発火させて既存のイベントリスナーと連携
+            this.textarea.dispatchEvent(new Event('input', { bubbles: true }));
+          }
+        })
+      ],
+      parent: container
+    });
+  }
+
+  setValue(value) {
+    if (this.view) {
+      this.view.dispatch({
+        changes: {
+          from: 0,
+          to: this.view.state.doc.length,
+          insert: value
+        }
+      });
+    }
+    this.textarea.value = value;
+  }
+
+  getValue() {
+    return this.view ? this.view.state.doc.toString() : this.textarea.value;
+  }
+
+  focus() {
+    if (this.view) {
+      this.view.focus();
+    }
+  }
+
+  destroy() {
+    if (this.view) {
+      this.view.destroy();
+      this.textarea.style.display = '';
+    }
+  }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -210,11 +210,19 @@ h3 {
 }
 
 /* アクティブ行のハイライトを無効化 */
-.codemirror-container .cm-activeLine {
+.cm-editor .cm-activeLine {
   background-color: transparent !important;
 }
 
-.codemirror-container .cm-activeLineGutter {
+.cm-editor .cm-activeLineGutter {
+  background-color: transparent !important;
+}
+
+.cm-editor .cm-activeLine {
+  background-color: transparent !important;
+}
+
+.cm-editor .cm-activeLineGutter {
   background-color: transparent !important;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -202,6 +202,22 @@ h3 {
   resize: vertical;
 }
 
+/* CodeMirrorエディタのスタイル */
+.codemirror-container .cm-editor {
+  background-color: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+}
+
+/* アクティブ行のハイライトを無効化 */
+.codemirror-container .cm-activeLine {
+  background-color: transparent !important;
+}
+
+.codemirror-container .cm-activeLineGutter {
+  background-color: transparent !important;
+}
+
 .button-container {
   display: flex;
   align-items: center;

--- a/test/test_e2e.js
+++ b/test/test_e2e.js
@@ -90,7 +90,7 @@ test.describe('E2E Challenge Tests', () => {
         await page.waitForTimeout(1000); // 問題データの読み込みを待つ
         
         // コードエディタをクリアして回答コードを入力
-        const codeEditor = page.locator('#code-editor');
+        const codeEditor = page.locator('.cm-content[contenteditable="true"]');
         await codeEditor.click();
         await codeEditor.fill(''); // クリア
         await codeEditor.fill(challenge.answerCode);


### PR DESCRIPTION
## Summary
- Added CodeMirror library for Ruby syntax highlighting in the code editor
- Implemented read-only syntax highlighting for Answer Example section
- Improved code readability with proper syntax coloring

<img width="493" height="202" alt="image" src="https://github.com/user-attachments/assets/2764dd84-3abe-4d9f-b425-510a068099d0" />

## Changes
- Integrated CodeMirror with Ruby language support for the main code editor
- Created `RubyEditor` class to manage the main editor with full editing capabilities
- Created `ReadOnlyRubyEditor` class for displaying answer code with syntax highlighting
- Updated styles to ensure consistent appearance across both editors
- Fixed E2E test to work with the new CodeMirror implementation

## Test plan
- [x] Manually tested editing code in the main editor
- [x] Verified syntax highlighting works correctly for Ruby code
- [x] Confirmed Answer Example displays with read-only syntax highlighting
- [x] Ensured E2E tests pass with the new implementation
- [x] Tested that all existing functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)